### PR TITLE
Switch to ClusterIP service type

### DIFF
--- a/kubernetes/akka-cluster.yml
+++ b/kubernetes/akka-cluster.yml
@@ -90,7 +90,7 @@ spec:
     targetPort: 8080
   selector:
     app: akka-kubernetes
-  type: LoadBalancer
+  type: ClusterIP
 ---
 # Can likely be changed to an Ingress
 apiVersion: route.openshift.io/v1


### PR DESCRIPTION
This was a mistake and results in an additional external load balancer being created.
As this is routed to via a Route then a ClusterIP is sufficient.