### PR TITLE
Plug small security hole in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ jobs:
   - stage: int-test
     script:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - curl -L https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz | tar xvz --strip 1 && chmod +x oc && sudo cp oc /usr/local/bin/ && rm oc
+    - curl -OL https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz
+    - echo "0f54235127884309d19b23e8e64e347f783efd6b5a94b49bfc4d0bf472efb5b8  openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz" | sha256sum -c
+    - tar --strip 1 -xvzf openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz && chmod +x oc && sudo cp oc /usr/local/bin/ && rm oc
     - oc login https://centralpark.lightbend.com --username=$OC_USERNAME --password=$OC_PASSWORD
     - oc status
     - oc project akka-kubernetes-tests


### PR DESCRIPTION
Verify the tarball before executing the `oc` binary, in case of compromise.